### PR TITLE
book: allow CSP-friendly search worker URL

### DIFF
--- a/src/book.ts
+++ b/src/book.ts
@@ -52,6 +52,7 @@ const INPUT_TYPE = {
  * @param {method} [options.canonical] optional function to determine canonical urls for a path
  * @param {string} [options.openAs] optional string to determine the input type
  * @param {string} [options.store=false] cache the contents in local storage, value should be the name of the reader
+ * @param {string} [options.searchWorkerUrl=undefined] optional URL for the search web worker script (CSP-friendly alternative to blob workers)
  * @returns {Book}
  * @example new Book("/path/to/book.epub", {})
  * @example new Book({ replacements: "blobUrl" })
@@ -85,7 +86,8 @@ class Book {
 			metrics: false,
 			prefetchDistance: 1,
 			maxLoadedSections: 0,
-			lazyResources: false
+			lazyResources: false,
+			searchWorkerUrl: undefined
 		});
 
 		extend(this.settings, options);
@@ -1741,6 +1743,10 @@ class Book {
 	}
 
 	createSearchWorker() {
+		if (this.settings && typeof this.settings.searchWorkerUrl === "string" && this.settings.searchWorkerUrl) {
+			return new Worker(this.settings.searchWorkerUrl);
+		}
+
 		const source = `
 self.onmessage = function(event) {
 	var data = event && event.data;

--- a/test/search-worker-csp.js
+++ b/test/search-worker-csp.js
@@ -1,0 +1,93 @@
+import assert from "assert";
+import Book from "../src/book";
+
+function setProp(obj, key, value) {
+	try {
+		obj[key] = value;
+	} catch (e) {
+		Object.defineProperty(obj, key, {
+			value,
+			configurable: true,
+			writable: true,
+		});
+	}
+}
+
+describe("Book.createSearchWorker CSP", function () {
+	it("uses searchWorkerUrl when provided (avoids blob: worker)", function () {
+		const originalWorker = window.Worker;
+		const originalCreateObjectURL = URL.createObjectURL;
+		const originalRevokeObjectURL = URL.revokeObjectURL;
+
+		try {
+			let createObjectURLCalled = false;
+			setProp(URL, "createObjectURL", () => {
+				createObjectURLCalled = true;
+				throw new Error("URL.createObjectURL should not be called when searchWorkerUrl is set");
+			});
+			setProp(URL, "revokeObjectURL", () => {
+				throw new Error("URL.revokeObjectURL should not be called when searchWorkerUrl is set");
+			});
+
+			let workerUrl = null;
+			function FakeWorker(url) {
+				workerUrl = url;
+				this.terminate = () => {};
+			}
+			setProp(window, "Worker", FakeWorker);
+
+			const worker = Book.prototype.createSearchWorker.call({
+				settings: { searchWorkerUrl: "https://example.invalid/search.worker.js" },
+			});
+
+			assert.ok(worker, "worker is returned");
+			assert.equal(workerUrl, "https://example.invalid/search.worker.js");
+			assert.equal(createObjectURLCalled, false);
+		} finally {
+			setProp(window, "Worker", originalWorker);
+			setProp(URL, "createObjectURL", originalCreateObjectURL);
+			setProp(URL, "revokeObjectURL", originalRevokeObjectURL);
+		}
+	});
+
+	it("falls back to blob: worker when searchWorkerUrl is not set", function () {
+		const originalWorker = window.Worker;
+		const originalCreateObjectURL = URL.createObjectURL;
+		const originalRevokeObjectURL = URL.revokeObjectURL;
+
+		try {
+			let createObjectURLCalled = false;
+			let revokeObjectURLCalled = false;
+			let createdWorkerUrl = null;
+
+			setProp(URL, "createObjectURL", () => {
+				createObjectURLCalled = true;
+				return "blob:fake-worker-url";
+			});
+			setProp(URL, "revokeObjectURL", (url) => {
+				revokeObjectURLCalled = true;
+				assert.equal(url, "blob:fake-worker-url");
+			});
+
+			function FakeWorker(url) {
+				createdWorkerUrl = url;
+				this.terminate = () => {};
+			}
+			setProp(window, "Worker", FakeWorker);
+
+			const worker = Book.prototype.createSearchWorker.call({
+				settings: {},
+			});
+
+			assert.ok(worker, "worker is returned");
+			assert.equal(createObjectURLCalled, true);
+			assert.equal(revokeObjectURLCalled, true);
+			assert.equal(createdWorkerUrl, "blob:fake-worker-url");
+		} finally {
+			setProp(window, "Worker", originalWorker);
+			setProp(URL, "createObjectURL", originalCreateObjectURL);
+			setProp(URL, "revokeObjectURL", originalRevokeObjectURL);
+		}
+	});
+});
+

--- a/types/book.d.ts
+++ b/types/book.d.ts
@@ -46,7 +46,8 @@ export interface BookOptions {
   metrics?: boolean | BookMetricsOptions,
   prefetchDistance?: number,
   maxLoadedSections?: number,
-  lazyResources?: boolean
+  lazyResources?: boolean,
+  searchWorkerUrl?: string
 }
 
 export default class Book {


### PR DESCRIPTION
Fixes #6.

Strict CSP environments often disallow `blob:` in `worker-src`, which breaks the current inline-blob worker creation. This change adds an escape hatch:

- New `BookOptions.searchWorkerUrl` (and runtime `book.settings.searchWorkerUrl`) to create the search worker via a normal URL.
- Keeps the existing `blob:` worker as the default fallback.

Tests:
- Added `test/search-worker-csp.js` to assert `searchWorkerUrl` bypasses `URL.createObjectURL` and that the blob fallback still calls `createObjectURL`/`revokeObjectURL`.
