### PR TITLE
security: gate scripted iframe content behind explicit opt-in

### DIFF
--- a/src/managers/continuous/index.ts
+++ b/src/managers/continuous/index.ts
@@ -23,6 +23,7 @@ class ContinuousViewManager extends DefaultViewManager {
 			snap: false,
 			afterScrolledTimeout: 10,
 			allowScriptedContent: false,
+			allowUnsafeScriptedContent: false,
 			allowPopups: false
 		});
 
@@ -42,6 +43,7 @@ class ContinuousViewManager extends DefaultViewManager {
 			height: 0,
 			forceEvenPages: false,
 			allowScriptedContent: this.settings.allowScriptedContent,
+			allowUnsafeScriptedContent: this.settings.allowUnsafeScriptedContent,
 			allowPopups: this.settings.allowPopups
 		};
 

--- a/src/managers/default/index.ts
+++ b/src/managers/default/index.ts
@@ -33,6 +33,7 @@ class DefaultViewManager {
 			snap: false,
 			afterScrolledTimeout: 20,
 			allowScriptedContent: false,
+			allowUnsafeScriptedContent: false,
 			allowPopups: false
 		});
 
@@ -48,6 +49,7 @@ class DefaultViewManager {
 			height: 0,
 			forceEvenPages: true,
 			allowScriptedContent: this.settings.allowScriptedContent,
+			allowUnsafeScriptedContent: this.settings.allowUnsafeScriptedContent,
 			allowPopups: this.settings.allowPopups
 		};
 

--- a/src/managers/views/iframe.ts
+++ b/src/managers/views/iframe.ts
@@ -72,6 +72,7 @@ class IframeView {
 			method: undefined,
 			forceRight: false,
 			allowScriptedContent: false,
+			allowUnsafeScriptedContent: false,
 			allowPopups: false
 		}, options || {});
 
@@ -147,13 +148,14 @@ class IframeView {
 		this.iframe.style.border = "none";
 
 		// sandbox
-		this.iframe.sandbox = "allow-same-origin";
-		if (this.settings.allowScriptedContent) {
-			this.iframe.sandbox += " allow-scripts";
+		let sandbox = "allow-same-origin";
+		if (this.settings.allowScriptedContent && this.settings.allowUnsafeScriptedContent) {
+			sandbox += " allow-scripts";
 		}
 		if (this.settings.allowPopups) {
-			this.iframe.sandbox += " allow-popups";
+			sandbox += " allow-popups";
 		}
+		this.iframe.setAttribute("sandbox", sandbox);
 		
 		this.iframe.setAttribute("enable-annotation", "true");
 

--- a/src/rendition.ts
+++ b/src/rendition.ts
@@ -44,6 +44,7 @@ import ContinuousViewManager from "./managers/continuous/index";
  * @param {boolean | object} [options.snap=false] use snap scrolling
  * @param {string} [options.defaultDirection='ltr'] default text direction
  * @param {boolean} [options.allowScriptedContent=false] enable running scripts in content
+ * @param {boolean} [options.allowUnsafeScriptedContent=false] required to actually enable scripts inside the iframe sandbox (unsafe)
  * @param {boolean} [options.allowPopups=false] enable opening popup in content
  * @param {boolean | number} [options.prefetch=false] prefetch neighboring sections after display
  */
@@ -73,6 +74,7 @@ class Rendition {
 			snap: false,
 			defaultDirection: "ltr",
 			allowScriptedContent: false,
+			allowUnsafeScriptedContent: false,
 			allowPopups: false,
 			openExternalLinks: true,
 			prefetch: false,

--- a/test/iframe-sandbox-security.js
+++ b/test/iframe-sandbox-security.js
@@ -1,0 +1,43 @@
+import assert from "assert";
+import IframeView from "../src/managers/views/iframe";
+
+function sandboxTokens(iframe) {
+  const value = iframe && typeof iframe.getAttribute === "function" ? iframe.getAttribute("sandbox") : "";
+  return String(value || "")
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+describe("IframeView sandbox scripted content", function () {
+  it("should not enable scripts unless allowUnsafeScriptedContent is set", function () {
+    const view = new IframeView({ index: 0 }, { allowScriptedContent: true });
+    const iframe = view.create();
+    const tokens = sandboxTokens(iframe);
+
+    assert.ok(tokens.includes("allow-same-origin"));
+    assert.ok(!tokens.includes("allow-scripts"));
+  });
+
+  it("should enable scripts only with explicit allowUnsafeScriptedContent opt-in", function () {
+    const view = new IframeView(
+      { index: 0 },
+      { allowScriptedContent: true, allowUnsafeScriptedContent: true }
+    );
+    const iframe = view.create();
+    const tokens = sandboxTokens(iframe);
+
+    assert.ok(tokens.includes("allow-same-origin"));
+    assert.ok(tokens.includes("allow-scripts"));
+  });
+
+  it("should keep allow-scripts disabled when allowScriptedContent is false", function () {
+    const view = new IframeView({ index: 0 }, { allowUnsafeScriptedContent: true });
+    const iframe = view.create();
+    const tokens = sandboxTokens(iframe);
+
+    assert.ok(tokens.includes("allow-same-origin"));
+    assert.ok(!tokens.includes("allow-scripts"));
+  });
+});
+

--- a/types/managers/view.d.ts
+++ b/types/managers/view.d.ts
@@ -7,12 +7,14 @@ export interface ViewSettings {
   axis?: string,
   flow?: string,
   layout?: Layout,
-  method?: string,
-  width?: number,
-  height?: number,
-  forceEvenPages?: boolean,
-  allowScriptedContent?: boolean
-}
+	  method?: string,
+	  width?: number,
+	  height?: number,
+	  forceEvenPages?: boolean,
+	  allowScriptedContent?: boolean,
+	  allowUnsafeScriptedContent?: boolean,
+	  allowPopups?: boolean
+	}
 
 export default class View {
   constructor(section: Section, options: ViewSettings);

--- a/types/rendition.d.ts
+++ b/types/rendition.d.ts
@@ -29,15 +29,16 @@ export interface RenditionOptions {
   script?: string,
   infinite?: boolean,
   overflow?: string,
-  snap?: boolean | object,
-  defaultDirection?: string,
-  allowScriptedContent?: boolean,
-  allowPopups?: boolean,
-  openExternalLinks?: boolean,
-  prefetch?: boolean | number,
-  footnotes?: boolean | { detect?: boolean, extract?: boolean },
-  fixedLayout?: null | { zoom?: number | "fit-width" | "fit-page" }
-}
+	  snap?: boolean | object,
+	  defaultDirection?: string,
+	  allowScriptedContent?: boolean,
+	  allowUnsafeScriptedContent?: boolean,
+	  allowPopups?: boolean,
+	  openExternalLinks?: boolean,
+	  prefetch?: boolean | number,
+	  footnotes?: boolean | { detect?: boolean, extract?: boolean },
+	  fixedLayout?: null | { zoom?: number | "fit-width" | "fit-page" }
+	}
 
 export interface DisplayedLocation {
   index: number,


### PR DESCRIPTION
Refs #4

This changes scripted content handling to be an explicit *double opt-in*.

- Add `allowUnsafeScriptedContent` (default: `false`).
- When `allowScriptedContent: true`, scripts are only enabled if `allowUnsafeScriptedContent: true`.
- Propagate the option through default / continuous managers into `IframeView`.
- Update TypeScript definitions.
- Add a regression test for the iframe sandbox tokens.

Security note: `allow-same-origin` + `allow-scripts` is intentionally guarded behind an explicit unsafe flag.
