### PR TITLE
fix: improve destroy() cleanup

### DIFF
--- a/src/book.ts
+++ b/src/book.ts
@@ -1904,6 +1904,13 @@ self.onmessage = function(event) {
 	 * Destroy the Book and all associated objects
 	 */
 	destroy() {
+		if (this._destroyed) {
+			return;
+		}
+		this._destroyed = true;
+
+		this.cancelPrefetch && this.cancelPrefetch();
+
 		this.opened = undefined;
 		this.loading = undefined;
 		this.loaded = undefined;
@@ -1913,6 +1920,9 @@ self.onmessage = function(event) {
 		this.isRendered = false;
 
 		this.performance && this.performance.reset();
+
+		this.storage && this.storage.destroy && this.storage.destroy();
+		this.spineLoader && this.spineLoader.destroy && this.spineLoader.destroy();
 
 		this.spine && this.spine.destroy();
 		this.locations && this.locations.destroy();
@@ -1929,14 +1939,17 @@ self.onmessage = function(event) {
 		this.pageList = undefined;
 		this.archive = undefined;
 		this.resources = undefined;
+		this.storage = undefined;
 		this.container = undefined;
 		this.packaging = undefined;
 		this.rendition = undefined;
+		this.displayOptions = undefined;
 
 		this.navigation = undefined;
 		this.url = undefined;
 		this.path = undefined;
 		this.archived = false;
+		this.obfuscation = undefined;
 		this.resourceResolver = undefined;
 		this.spineLoader = undefined;
 		this.performance = undefined;

--- a/src/core/spine-loader.ts
+++ b/src/core/spine-loader.ts
@@ -247,6 +247,25 @@ class SpineLoader {
 		return candidates;
 	}
 
+	destroy(): void {
+		this.cancelPrefetch();
+
+		for (const section of Array.from(this.loadedSections.values())) {
+			if (section && typeof section.unload === "function") {
+				try {
+					section.unload();
+				} catch (e) {
+					// NOOP
+				}
+			}
+		}
+
+		this.pinnedSections.clear();
+		this.loadedSections.clear();
+		this.loadedOrder = [];
+		this.performance = undefined;
+	}
+
 	private normalizeMaxLoadedSections(maxLoadedSections: SpineLoaderOptions["maxLoadedSections"]): number {
 		if (maxLoadedSections === false || maxLoadedSections === 0) {
 			return Infinity;

--- a/src/rendition.ts
+++ b/src/rendition.ts
@@ -103,21 +103,24 @@ class Rendition {
 		this.hooks.render = new Hook(this);
 		this.hooks.show = new Hook(this);
 		this.hooks.header = new Hook(this);
-		this.hooks.footer = new Hook(this);
+			this.hooks.footer = new Hook(this);
 
-		this.hooks.content.register(this.handleLinks.bind(this));
-		this.hooks.content.register(this.passEvents.bind(this));
-		this.hooks.content.register(this.adjustImages.bind(this));
+			this.hooks.content.register(this.handleLinks.bind(this));
+			this.hooks.content.register(this.passEvents.bind(this));
+			this.hooks.content.register(this.adjustImages.bind(this));
 
-		this.book.spine.hooks.content.register(this.injectIdentifier.bind(this));
+			this._onSpineInjectIdentifier = this.injectIdentifier.bind(this);
+			this.book.spine.hooks.content.register(this._onSpineInjectIdentifier);
 
-		if (this.settings.stylesheet) {
-			this.book.spine.hooks.content.register(this.injectStylesheet.bind(this));
-		}
+			if (this.settings.stylesheet) {
+				this._onSpineInjectStylesheet = this.injectStylesheet.bind(this);
+				this.book.spine.hooks.content.register(this._onSpineInjectStylesheet);
+			}
 
-		if (this.settings.script) {
-			this.book.spine.hooks.content.register(this.injectScript.bind(this));
-		}
+			if (this.settings.script) {
+				this._onSpineInjectScript = this.injectScript.bind(this);
+				this.book.spine.hooks.content.register(this._onSpineInjectScript);
+			}
 
 		/**
 		 * @member {Themes} themes
@@ -161,14 +164,15 @@ class Rendition {
 		 * @property {boolean} atEnd
 		 * @memberof Rendition
 		 */
-		this.location = undefined;
-		this._hasRequestedDisplay = false;
-		this._lastRequestedTarget = undefined;
+			this.location = undefined;
+			this._hasRequestedDisplay = false;
+			this._lastRequestedTarget = undefined;
+			this._destroyed = false;
 
-		// Hold queue until book is opened
-		this.q.enqueue(this.book.opened);
+			// Hold queue until book is opened
+			this.q.enqueue(this.book.opened);
 
-		this.starting = new defer();
+			this.starting = new defer();
 		/**
 		 * @member {promise} started returns after the rendition has started
 		 * @memberof Rendition
@@ -265,18 +269,33 @@ class Rendition {
 
 		this.layout(this.settings.globalLayoutProperties);
 
-		// Listen for displayed views
-		this.manager.on(EVENTS.MANAGERS.ADDED, this.afterDisplayed.bind(this));
-		this.manager.on(EVENTS.MANAGERS.REMOVED, this.afterRemoved.bind(this));
+			// Listen for displayed views
+			if (!this._onManagerAdded) {
+				this._onManagerAdded = this.afterDisplayed.bind(this);
+			}
+			if (!this._onManagerRemoved) {
+				this._onManagerRemoved = this.afterRemoved.bind(this);
+			}
+			this.manager.on(EVENTS.MANAGERS.ADDED, this._onManagerAdded);
+			this.manager.on(EVENTS.MANAGERS.REMOVED, this._onManagerRemoved);
 
-		// Listen for resizing
-		this.manager.on(EVENTS.MANAGERS.RESIZED, this.onResized.bind(this));
+			// Listen for resizing
+			if (!this._onManagerResized) {
+				this._onManagerResized = this.onResized.bind(this);
+			}
+			this.manager.on(EVENTS.MANAGERS.RESIZED, this._onManagerResized);
 
-		// Listen for rotation
-		this.manager.on(EVENTS.MANAGERS.ORIENTATION_CHANGE, this.onOrientationChange.bind(this));
+			// Listen for rotation
+			if (!this._onManagerOrientationChange) {
+				this._onManagerOrientationChange = this.onOrientationChange.bind(this);
+			}
+			this.manager.on(EVENTS.MANAGERS.ORIENTATION_CHANGE, this._onManagerOrientationChange);
 
-		// Listen for scroll changes
-		this.manager.on(EVENTS.MANAGERS.SCROLLED, this.reportLocation.bind(this));
+			// Listen for scroll changes
+			if (!this._onManagerScrolled) {
+				this._onManagerScrolled = this.reportLocation.bind(this);
+			}
+			this.manager.on(EVENTS.MANAGERS.SCROLLED, this._onManagerScrolled);
 
 		/**
 		 * Emit that rendering has started
@@ -698,17 +717,28 @@ class Rendition {
 	 * Adjust the layout of the rendition to reflowable or pre-paginated
 	 * @param  {object} settings
 	 */
-	layout(settings){
-		if (settings) {
-			this._layout = new Layout(settings);
-			this._layout.spread(settings.spread, this.settings.minSpreadWidth);
+		layout(settings){
+			if (settings) {
+				if (this._layout && this._onLayoutUpdated && typeof this._layout.off === "function") {
+					try {
+						this._layout.off(EVENTS.LAYOUT.UPDATED, this._onLayoutUpdated);
+					} catch (e) {
+						// NOOP
+					}
+				}
+
+				this._layout = new Layout(settings);
+				this._layout.spread(settings.spread, this.settings.minSpreadWidth);
 
 			// this.mapping = new Mapping(this._layout.props);
 
-			this._layout.on(EVENTS.LAYOUT.UPDATED, (props, changed) => {
-				this.emit(EVENTS.RENDITION.LAYOUT, props, changed);
-			})
-		}
+				if (!this._onLayoutUpdated) {
+					this._onLayoutUpdated = (props, changed) => {
+						this.emit(EVENTS.RENDITION.LAYOUT, props, changed);
+					};
+				}
+				this._layout.on(EVENTS.LAYOUT.UPDATED, this._onLayoutUpdated);
+			}
 
 		if (this.manager && this._layout) {
 			this.manager.applyLayout(this._layout);
@@ -962,38 +992,102 @@ class Rendition {
 		return located;
 	}
 
-	/**
-	 * Remove and Clean Up the Rendition
-	 */
-	destroy(){
-		// Clear the queue
-		// this.q.clear();
-		// this.q = undefined;
+		/**
+		 * Remove and Clean Up the Rendition
+		 */
+		destroy(){
+			if (this._destroyed) {
+				return;
+			}
+			this._destroyed = true;
 
-		this.manager && this.manager.destroy();
+			if (this.q && typeof this.q.stop === "function") {
+				this.q.stop();
+			}
 
-		this.book = undefined;
+			if (this._layout && this._onLayoutUpdated && typeof this._layout.off === "function") {
+				try {
+					this._layout.off(EVENTS.LAYOUT.UPDATED, this._onLayoutUpdated);
+				} catch (e) {
+					// NOOP
+				}
+			}
+			this._onLayoutUpdated = undefined;
 
-		// this.views = null;
+			if (this.manager) {
+				if (this._onManagerAdded && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.ADDED, this._onManagerAdded);
+				}
+				if (this._onManagerRemoved && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.REMOVED, this._onManagerRemoved);
+				}
+				if (this._onManagerResized && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.RESIZED, this._onManagerResized);
+				}
+				if (this._onManagerOrientationChange && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.ORIENTATION_CHANGE, this._onManagerOrientationChange);
+				}
+				if (this._onManagerScrolled && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.SCROLLED, this._onManagerScrolled);
+				}
 
-		// this.hooks.display.clear();
-		// this.hooks.serialize.clear();
-		// this.hooks.content.clear();
-		// this.hooks.layout.clear();
-		// this.hooks.render.clear();
-		// this.hooks.show.clear();
-		// this.hooks = {};
+				try {
+					typeof this.manager.destroy === "function" && this.manager.destroy();
+				} catch (e) {
+					// NOOP
+				}
+			}
 
-		// this.themes.destroy();
-		// this.themes = undefined;
+			this._onManagerAdded = undefined;
+			this._onManagerRemoved = undefined;
+			this._onManagerResized = undefined;
+			this._onManagerOrientationChange = undefined;
+			this._onManagerScrolled = undefined;
 
-		// this.epubcfi = undefined;
+			const spineContentHooks =
+				this.book &&
+				this.book.spine &&
+				this.book.spine.hooks &&
+				this.book.spine.hooks.content;
+			if (spineContentHooks && typeof spineContentHooks.deregister === "function") {
+				this._onSpineInjectIdentifier &&
+					spineContentHooks.deregister(this._onSpineInjectIdentifier);
+				this._onSpineInjectStylesheet &&
+					spineContentHooks.deregister(this._onSpineInjectStylesheet);
+				this._onSpineInjectScript &&
+					spineContentHooks.deregister(this._onSpineInjectScript);
+			}
 
-		// this.starting = undefined;
-		// this.started = undefined;
+			this._onSpineInjectIdentifier = undefined;
+			this._onSpineInjectStylesheet = undefined;
+			this._onSpineInjectScript = undefined;
 
+			if (this.hooks) {
+				for (const key in this.hooks) {
+					const hook = this.hooks[key];
+					hook && typeof hook.clear === "function" && hook.clear();
+				}
+			}
 
-	}
+			if (this.themes && typeof this.themes.destroy === "function") {
+				this.themes.destroy();
+			}
+
+			this.themes = undefined;
+			this.annotations = undefined;
+			this.hooks = undefined;
+
+			this.manager = undefined;
+			this.View = undefined;
+			this.ViewManager = undefined;
+			this.book = undefined;
+			this.displaying = undefined;
+			this.location = undefined;
+			this._layout = undefined;
+			this.q = undefined;
+			this.starting = undefined;
+			this.started = undefined;
+		}
 
 	/**
 	 * Pass the events from a view's Contents

--- a/test/destroy-cleanup.js
+++ b/test/destroy-cleanup.js
@@ -1,0 +1,94 @@
+import assert from "assert";
+import Hook from "../src/utils/hook";
+import Rendition from "../src/rendition";
+import { EVENTS } from "../src/utils/constants";
+
+function createStubManager() {
+  const listeners = new Map();
+  const calls = { on: [], off: [], destroy: 0 };
+
+  return {
+    listeners,
+    calls,
+    on(event, fn) {
+      calls.on.push([event, fn]);
+      const existing = listeners.get(event) || [];
+      existing.push(fn);
+      listeners.set(event, existing);
+      return this;
+    },
+    off(event, fn) {
+      calls.off.push([event, fn]);
+      const existing = listeners.get(event) || [];
+      const filtered = existing.filter((candidate) => candidate !== fn);
+      if (filtered.length) {
+        listeners.set(event, filtered);
+      } else {
+        listeners.delete(event);
+      }
+      return this;
+    },
+    destroy() {
+      calls.destroy += 1;
+    },
+    applyLayout() {},
+    updateFlow() {},
+    direction() {},
+    isRendered() {
+      return false;
+    },
+    clear() {},
+  };
+}
+
+function createStubBook(spineContentHook) {
+  return {
+    opened: Promise.resolve(),
+    spine: { hooks: { content: spineContentHook } },
+    package: { metadata: { layout: "reflowable", spread: "auto", direction: "ltr" } },
+    displayOptions: { fixedLayout: "false" },
+  };
+}
+
+describe("destroy() cleanup", function () {
+  it("should deregister spine content hooks registered by Rendition", async function () {
+    const spineContentHook = new Hook();
+    const manager = createStubManager();
+    const book = createStubBook(spineContentHook);
+
+    const rendition = new Rendition(book, {
+      manager,
+      stylesheet: "/styles.css",
+      script: "/script.js",
+    });
+
+    await rendition.started;
+
+    assert.equal(spineContentHook.list().length, 3);
+
+    rendition.destroy();
+
+    assert.equal(spineContentHook.list().length, 0);
+  });
+
+  it("should detach manager event listeners on Rendition.destroy()", async function () {
+    const spineContentHook = new Hook();
+    const manager = createStubManager();
+    const book = createStubBook(spineContentHook);
+
+    const rendition = new Rendition(book, { manager });
+    await rendition.started;
+
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.ADDED));
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.REMOVED));
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.RESIZED));
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.ORIENTATION_CHANGE));
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.SCROLLED));
+
+    rendition.destroy();
+
+    assert.equal(manager.calls.destroy, 1);
+    assert.equal(manager.listeners.size, 0);
+  });
+});
+


### PR DESCRIPTION
Fixes #7

- Make `Rendition.destroy()` idempotent and remove internal references that keep renditions alive after disposal:
  - store + `off()` manager event handlers
  - store + `deregister()` spine content hooks registered by `Rendition`
  - stop the internal queue
  - detach the Layout updated listener
  - clear hooks and release themes/annotations references
- Improve `Book.destroy()` cleanup:
  - cancel and destroy prefetch loader
  - destroy storage (removes online/offline listeners)
  - clear additional references (e.g. `displayOptions`)
- Add `SpineLoader.destroy()` to unload cached sections and abort in-flight prefetch.

Tests: add `test/destroy-cleanup.js` to assert hook and listener deregistration.
