### PR TITLE
perf: avoid updateLayout during scroll location

### DIFF
--- a/src/managers/default/index.ts
+++ b/src/managers/default/index.ts
@@ -38,22 +38,23 @@ class DefaultViewManager {
 
 		extend(this.settings, options.settings || {});
 
-		this.viewSettings = {
-			ignoreClass: this.settings.ignoreClass,
-			axis: this.settings.axis,
-			flow: this.settings.flow,
+			this.viewSettings = {
+				ignoreClass: this.settings.ignoreClass,
+				axis: this.settings.axis,
+				flow: this.settings.flow,
 			layout: this.layout,
 			method: this.settings.method, // srcdoc, blobUrl, write
 			width: 0,
 			height: 0,
 			forceEvenPages: true,
-			allowScriptedContent: this.settings.allowScriptedContent,
-			allowPopups: this.settings.allowPopups
-		};
+				allowScriptedContent: this.settings.allowScriptedContent,
+				allowPopups: this.settings.allowPopups
+			};
 
-		this.rendered = false;
+			this._layoutNeedsUpdate = true;
+			this.rendered = false;
 
-	}
+		}
 
 	render(element, size){
 		let tag = element.tagName;
@@ -744,15 +745,17 @@ class DefaultViewManager {
 		}
 	}
 
-	currentLocation(){
-		this.updateLayout();
-		if (this.isPaginated && this.settings.axis === "horizontal") {
-			this.location = this.paginatedLocation();
-		} else {
-			this.location = this.scrolledLocation();
+		currentLocation(){
+			if (this._layoutNeedsUpdate || !this._stageSize) {
+				this.updateLayout();
+			}
+			if (this.isPaginated && this.settings.axis === "horizontal") {
+				this.location = this.paginatedLocation();
+			} else {
+				this.location = this.scrolledLocation();
+			}
+			return this.location;
 		}
-		return this.location;
-	}
 
 	scrolledLocation() {
 		let visible = this.visible();
@@ -1025,23 +1028,24 @@ class DefaultViewManager {
 		return bounds;
 	}
 
-	applyLayout(layout) {
+		applyLayout(layout) {
 
-		this.layout = layout;
-		this.updateLayout();
-		if (this.views && this.views.length > 0 && this.layout.name === "pre-paginated") {
-			this.display(this.views.first().section);
-		}
+			this.layout = layout;
+			this._layoutNeedsUpdate = true;
+			this.updateLayout();
+			if (this.views && this.views.length > 0 && this.layout.name === "pre-paginated") {
+				this.display(this.views.first().section);
+			}
 		 // this.manager.layout(this.layout.format);
 	}
 
-	updateLayout() {
+		updateLayout() {
 
-		if (!this.stage) {
-			return;
-		}
+			if (!this.stage) {
+				return;
+			}
 
-		this._stageSize = this.stage.size();
+			this._stageSize = this.stage.size();
 
 		if(!this.isPaginated) {
 			this.layout.calculate(this._stageSize.width, this._stageSize.height);
@@ -1061,11 +1065,12 @@ class DefaultViewManager {
 		}
 
 		// Set the dimensions for views
-		this.viewSettings.width = this.layout.width;
-		this.viewSettings.height = this.layout.height;
+			this.viewSettings.width = this.layout.width;
+			this.viewSettings.height = this.layout.height;
 
-		this.setLayout(this.layout);
-	}
+			this.setLayout(this.layout);
+			this._layoutNeedsUpdate = false;
+		}
 
 	setLayout(layout){
 

--- a/test/current-location-layout-cache.js
+++ b/test/current-location-layout-cache.js
@@ -1,0 +1,37 @@
+import assert from "assert";
+import DefaultViewManager from "../src/managers/default";
+
+describe("DefaultViewManager currentLocation layout caching", function () {
+  it("should only call updateLayout when layout is dirty", function () {
+    const calls = { updateLayout: 0 };
+    const manager = {
+      _layoutNeedsUpdate: false,
+      _stageSize: { width: 100, height: 200 },
+      isPaginated: false,
+      settings: { axis: "vertical" },
+      updateLayout() {
+        calls.updateLayout += 1;
+        this._layoutNeedsUpdate = false;
+        this._stageSize = { width: 100, height: 200 };
+      },
+      scrolledLocation() {
+        return { kind: "scrolled" };
+      },
+      paginatedLocation() {
+        return { kind: "paginated" };
+      },
+    };
+
+    DefaultViewManager.prototype.currentLocation.call(manager);
+    DefaultViewManager.prototype.currentLocation.call(manager);
+    assert.equal(calls.updateLayout, 0);
+
+    manager._layoutNeedsUpdate = true;
+    DefaultViewManager.prototype.currentLocation.call(manager);
+    assert.equal(calls.updateLayout, 1);
+
+    DefaultViewManager.prototype.currentLocation.call(manager);
+    assert.equal(calls.updateLayout, 1);
+  });
+});
+


### PR DESCRIPTION
Fixes #8

- Avoid calling `updateLayout()` (and therefore `stage.size()`) on every `currentLocation()` call.
- Track a `_layoutNeedsUpdate` flag and only recompute layout when the stage or layout changes.
- Add a unit test to ensure `currentLocation()` does not invoke `updateLayout()` unless dirty.
