### PR TITLE
fix: bind epubcfi.compare when used as callback

### DIFF
--- a/src/book.ts
+++ b/src/book.ts
@@ -52,6 +52,7 @@ const INPUT_TYPE = {
  * @param {method} [options.canonical] optional function to determine canonical urls for a path
  * @param {string} [options.openAs] optional string to determine the input type
  * @param {string} [options.store=false] cache the contents in local storage, value should be the name of the reader
+ * @param {string} [options.searchWorkerUrl=undefined] optional URL for the search web worker script (CSP-friendly alternative to blob workers)
  * @returns {Book}
  * @example new Book("/path/to/book.epub", {})
  * @example new Book({ replacements: "blobUrl" })
@@ -85,7 +86,8 @@ class Book {
 			metrics: false,
 			prefetchDistance: 1,
 			maxLoadedSections: 0,
-			lazyResources: false
+			lazyResources: false,
+			searchWorkerUrl: undefined
 		});
 
 		extend(this.settings, options);
@@ -1741,6 +1743,10 @@ class Book {
 	}
 
 	createSearchWorker() {
+		if (this.settings && typeof this.settings.searchWorkerUrl === "string" && this.settings.searchWorkerUrl) {
+			return new Worker(this.settings.searchWorkerUrl);
+		}
+
 		const source = `
 self.onmessage = function(event) {
 	var data = event && event.data;

--- a/src/book.ts
+++ b/src/book.ts
@@ -1904,6 +1904,13 @@ self.onmessage = function(event) {
 	 * Destroy the Book and all associated objects
 	 */
 	destroy() {
+		if (this._destroyed) {
+			return;
+		}
+		this._destroyed = true;
+
+		this.cancelPrefetch && this.cancelPrefetch();
+
 		this.opened = undefined;
 		this.loading = undefined;
 		this.loaded = undefined;
@@ -1913,6 +1920,9 @@ self.onmessage = function(event) {
 		this.isRendered = false;
 
 		this.performance && this.performance.reset();
+
+		this.storage && this.storage.destroy && this.storage.destroy();
+		this.spineLoader && this.spineLoader.destroy && this.spineLoader.destroy();
 
 		this.spine && this.spine.destroy();
 		this.locations && this.locations.destroy();
@@ -1929,14 +1939,17 @@ self.onmessage = function(event) {
 		this.pageList = undefined;
 		this.archive = undefined;
 		this.resources = undefined;
+		this.storage = undefined;
 		this.container = undefined;
 		this.packaging = undefined;
 		this.rendition = undefined;
+		this.displayOptions = undefined;
 
 		this.navigation = undefined;
 		this.url = undefined;
 		this.path = undefined;
 		this.archived = false;
+		this.obfuscation = undefined;
 		this.resourceResolver = undefined;
 		this.spineLoader = undefined;
 		this.performance = undefined;

--- a/src/core/spine-loader.ts
+++ b/src/core/spine-loader.ts
@@ -247,6 +247,25 @@ class SpineLoader {
 		return candidates;
 	}
 
+	destroy(): void {
+		this.cancelPrefetch();
+
+		for (const section of Array.from(this.loadedSections.values())) {
+			if (section && typeof section.unload === "function") {
+				try {
+					section.unload();
+				} catch (e) {
+					// NOOP
+				}
+			}
+		}
+
+		this.pinnedSections.clear();
+		this.loadedSections.clear();
+		this.loadedOrder = [];
+		this.performance = undefined;
+	}
+
 	private normalizeMaxLoadedSections(maxLoadedSections: SpineLoaderOptions["maxLoadedSections"]): number {
 		if (maxLoadedSections === false || maxLoadedSections === 0) {
 			return Infinity;

--- a/src/locations.ts
+++ b/src/locations.ts
@@ -586,7 +586,8 @@ self.onmessage = (event) => {
 			return -1;
 		}
 
-		loc = locationOf(cfi, this._locations, this.epubcfi.compare);
+			const compare = this.epubcfi.compare.bind(this.epubcfi);
+			loc = locationOf(cfi, this._locations, compare);
 
 		if (loc > this.total) {
 			return this.total;

--- a/src/managers/continuous/index.ts
+++ b/src/managers/continuous/index.ts
@@ -23,6 +23,7 @@ class ContinuousViewManager extends DefaultViewManager {
 			snap: false,
 			afterScrolledTimeout: 10,
 			allowScriptedContent: false,
+			allowUnsafeScriptedContent: false,
 			allowPopups: false
 		});
 
@@ -42,6 +43,7 @@ class ContinuousViewManager extends DefaultViewManager {
 			height: 0,
 			forceEvenPages: false,
 			allowScriptedContent: this.settings.allowScriptedContent,
+			allowUnsafeScriptedContent: this.settings.allowUnsafeScriptedContent,
 			allowPopups: this.settings.allowPopups
 		};
 

--- a/src/managers/default/index.ts
+++ b/src/managers/default/index.ts
@@ -33,6 +33,7 @@ class DefaultViewManager {
 			snap: false,
 			afterScrolledTimeout: 20,
 			allowScriptedContent: false,
+			allowUnsafeScriptedContent: false,
 			allowPopups: false
 		});
 
@@ -48,6 +49,7 @@ class DefaultViewManager {
 			height: 0,
 			forceEvenPages: true,
 			allowScriptedContent: this.settings.allowScriptedContent,
+			allowUnsafeScriptedContent: this.settings.allowUnsafeScriptedContent,
 			allowPopups: this.settings.allowPopups
 		};
 

--- a/src/managers/default/index.ts
+++ b/src/managers/default/index.ts
@@ -38,22 +38,23 @@ class DefaultViewManager {
 
 		extend(this.settings, options.settings || {});
 
-		this.viewSettings = {
-			ignoreClass: this.settings.ignoreClass,
-			axis: this.settings.axis,
-			flow: this.settings.flow,
+			this.viewSettings = {
+				ignoreClass: this.settings.ignoreClass,
+				axis: this.settings.axis,
+				flow: this.settings.flow,
 			layout: this.layout,
 			method: this.settings.method, // srcdoc, blobUrl, write
 			width: 0,
 			height: 0,
 			forceEvenPages: true,
-			allowScriptedContent: this.settings.allowScriptedContent,
-			allowPopups: this.settings.allowPopups
-		};
+				allowScriptedContent: this.settings.allowScriptedContent,
+				allowPopups: this.settings.allowPopups
+			};
 
-		this.rendered = false;
+			this._layoutNeedsUpdate = true;
+			this.rendered = false;
 
-	}
+		}
 
 	render(element, size){
 		let tag = element.tagName;
@@ -744,15 +745,17 @@ class DefaultViewManager {
 		}
 	}
 
-	currentLocation(){
-		this.updateLayout();
-		if (this.isPaginated && this.settings.axis === "horizontal") {
-			this.location = this.paginatedLocation();
-		} else {
-			this.location = this.scrolledLocation();
+		currentLocation(){
+			if (this._layoutNeedsUpdate || !this._stageSize) {
+				this.updateLayout();
+			}
+			if (this.isPaginated && this.settings.axis === "horizontal") {
+				this.location = this.paginatedLocation();
+			} else {
+				this.location = this.scrolledLocation();
+			}
+			return this.location;
 		}
-		return this.location;
-	}
 
 	scrolledLocation() {
 		let visible = this.visible();
@@ -1025,23 +1028,24 @@ class DefaultViewManager {
 		return bounds;
 	}
 
-	applyLayout(layout) {
+		applyLayout(layout) {
 
-		this.layout = layout;
-		this.updateLayout();
-		if (this.views && this.views.length > 0 && this.layout.name === "pre-paginated") {
-			this.display(this.views.first().section);
-		}
+			this.layout = layout;
+			this._layoutNeedsUpdate = true;
+			this.updateLayout();
+			if (this.views && this.views.length > 0 && this.layout.name === "pre-paginated") {
+				this.display(this.views.first().section);
+			}
 		 // this.manager.layout(this.layout.format);
 	}
 
-	updateLayout() {
+		updateLayout() {
 
-		if (!this.stage) {
-			return;
-		}
+			if (!this.stage) {
+				return;
+			}
 
-		this._stageSize = this.stage.size();
+			this._stageSize = this.stage.size();
 
 		if(!this.isPaginated) {
 			this.layout.calculate(this._stageSize.width, this._stageSize.height);
@@ -1061,11 +1065,12 @@ class DefaultViewManager {
 		}
 
 		// Set the dimensions for views
-		this.viewSettings.width = this.layout.width;
-		this.viewSettings.height = this.layout.height;
+			this.viewSettings.width = this.layout.width;
+			this.viewSettings.height = this.layout.height;
 
-		this.setLayout(this.layout);
-	}
+			this.setLayout(this.layout);
+			this._layoutNeedsUpdate = false;
+		}
 
 	setLayout(layout){
 

--- a/src/managers/views/iframe.ts
+++ b/src/managers/views/iframe.ts
@@ -72,6 +72,7 @@ class IframeView {
 			method: undefined,
 			forceRight: false,
 			allowScriptedContent: false,
+			allowUnsafeScriptedContent: false,
 			allowPopups: false
 		}, options || {});
 
@@ -147,13 +148,14 @@ class IframeView {
 		this.iframe.style.border = "none";
 
 		// sandbox
-		this.iframe.sandbox = "allow-same-origin";
-		if (this.settings.allowScriptedContent) {
-			this.iframe.sandbox += " allow-scripts";
+		let sandbox = "allow-same-origin";
+		if (this.settings.allowScriptedContent && this.settings.allowUnsafeScriptedContent) {
+			sandbox += " allow-scripts";
 		}
 		if (this.settings.allowPopups) {
-			this.iframe.sandbox += " allow-popups";
+			sandbox += " allow-popups";
 		}
+		this.iframe.setAttribute("sandbox", sandbox);
 		
 		this.iframe.setAttribute("enable-annotation", "true");
 

--- a/src/pagelist.ts
+++ b/src/pagelist.ts
@@ -207,14 +207,15 @@ class PageList {
 			return -1;
 		}
 
-		var index = indexOfSorted(cfi, this.locations, epubcfi.compare);
+			const compare = epubcfi.compare.bind(epubcfi);
+			var index = indexOfSorted(cfi, this.locations, compare);
 		if(index != -1) {
 			pg = this.pages[index];
 		} else {
 			// Otherwise add it to the list of locations
 			// Insert it in the correct position in the locations page
 			//index = EPUBJS.core.insert(cfi, this.locations, this.epubcfi.compare);
-			index = locationOf(cfi, this.locations, epubcfi.compare);
+				index = locationOf(cfi, this.locations, compare);
 			// Get the page at the location just before the new one, or return the first
 			pg = index-1 >= 0 ? this.pages[index-1] : this.pages[0];
 			if(pg !== undefined) {

--- a/src/rendition.ts
+++ b/src/rendition.ts
@@ -103,21 +103,24 @@ class Rendition {
 		this.hooks.render = new Hook(this);
 		this.hooks.show = new Hook(this);
 		this.hooks.header = new Hook(this);
-		this.hooks.footer = new Hook(this);
+			this.hooks.footer = new Hook(this);
 
-		this.hooks.content.register(this.handleLinks.bind(this));
-		this.hooks.content.register(this.passEvents.bind(this));
-		this.hooks.content.register(this.adjustImages.bind(this));
+			this.hooks.content.register(this.handleLinks.bind(this));
+			this.hooks.content.register(this.passEvents.bind(this));
+			this.hooks.content.register(this.adjustImages.bind(this));
 
-		this.book.spine.hooks.content.register(this.injectIdentifier.bind(this));
+			this._onSpineInjectIdentifier = this.injectIdentifier.bind(this);
+			this.book.spine.hooks.content.register(this._onSpineInjectIdentifier);
 
-		if (this.settings.stylesheet) {
-			this.book.spine.hooks.content.register(this.injectStylesheet.bind(this));
-		}
+			if (this.settings.stylesheet) {
+				this._onSpineInjectStylesheet = this.injectStylesheet.bind(this);
+				this.book.spine.hooks.content.register(this._onSpineInjectStylesheet);
+			}
 
-		if (this.settings.script) {
-			this.book.spine.hooks.content.register(this.injectScript.bind(this));
-		}
+			if (this.settings.script) {
+				this._onSpineInjectScript = this.injectScript.bind(this);
+				this.book.spine.hooks.content.register(this._onSpineInjectScript);
+			}
 
 		/**
 		 * @member {Themes} themes
@@ -161,14 +164,15 @@ class Rendition {
 		 * @property {boolean} atEnd
 		 * @memberof Rendition
 		 */
-		this.location = undefined;
-		this._hasRequestedDisplay = false;
-		this._lastRequestedTarget = undefined;
+			this.location = undefined;
+			this._hasRequestedDisplay = false;
+			this._lastRequestedTarget = undefined;
+			this._destroyed = false;
 
-		// Hold queue until book is opened
-		this.q.enqueue(this.book.opened);
+			// Hold queue until book is opened
+			this.q.enqueue(this.book.opened);
 
-		this.starting = new defer();
+			this.starting = new defer();
 		/**
 		 * @member {promise} started returns after the rendition has started
 		 * @memberof Rendition
@@ -265,18 +269,33 @@ class Rendition {
 
 		this.layout(this.settings.globalLayoutProperties);
 
-		// Listen for displayed views
-		this.manager.on(EVENTS.MANAGERS.ADDED, this.afterDisplayed.bind(this));
-		this.manager.on(EVENTS.MANAGERS.REMOVED, this.afterRemoved.bind(this));
+			// Listen for displayed views
+			if (!this._onManagerAdded) {
+				this._onManagerAdded = this.afterDisplayed.bind(this);
+			}
+			if (!this._onManagerRemoved) {
+				this._onManagerRemoved = this.afterRemoved.bind(this);
+			}
+			this.manager.on(EVENTS.MANAGERS.ADDED, this._onManagerAdded);
+			this.manager.on(EVENTS.MANAGERS.REMOVED, this._onManagerRemoved);
 
-		// Listen for resizing
-		this.manager.on(EVENTS.MANAGERS.RESIZED, this.onResized.bind(this));
+			// Listen for resizing
+			if (!this._onManagerResized) {
+				this._onManagerResized = this.onResized.bind(this);
+			}
+			this.manager.on(EVENTS.MANAGERS.RESIZED, this._onManagerResized);
 
-		// Listen for rotation
-		this.manager.on(EVENTS.MANAGERS.ORIENTATION_CHANGE, this.onOrientationChange.bind(this));
+			// Listen for rotation
+			if (!this._onManagerOrientationChange) {
+				this._onManagerOrientationChange = this.onOrientationChange.bind(this);
+			}
+			this.manager.on(EVENTS.MANAGERS.ORIENTATION_CHANGE, this._onManagerOrientationChange);
 
-		// Listen for scroll changes
-		this.manager.on(EVENTS.MANAGERS.SCROLLED, this.reportLocation.bind(this));
+			// Listen for scroll changes
+			if (!this._onManagerScrolled) {
+				this._onManagerScrolled = this.reportLocation.bind(this);
+			}
+			this.manager.on(EVENTS.MANAGERS.SCROLLED, this._onManagerScrolled);
 
 		/**
 		 * Emit that rendering has started
@@ -698,17 +717,28 @@ class Rendition {
 	 * Adjust the layout of the rendition to reflowable or pre-paginated
 	 * @param  {object} settings
 	 */
-	layout(settings){
-		if (settings) {
-			this._layout = new Layout(settings);
-			this._layout.spread(settings.spread, this.settings.minSpreadWidth);
+		layout(settings){
+			if (settings) {
+				if (this._layout && this._onLayoutUpdated && typeof this._layout.off === "function") {
+					try {
+						this._layout.off(EVENTS.LAYOUT.UPDATED, this._onLayoutUpdated);
+					} catch (e) {
+						// NOOP
+					}
+				}
+
+				this._layout = new Layout(settings);
+				this._layout.spread(settings.spread, this.settings.minSpreadWidth);
 
 			// this.mapping = new Mapping(this._layout.props);
 
-			this._layout.on(EVENTS.LAYOUT.UPDATED, (props, changed) => {
-				this.emit(EVENTS.RENDITION.LAYOUT, props, changed);
-			})
-		}
+				if (!this._onLayoutUpdated) {
+					this._onLayoutUpdated = (props, changed) => {
+						this.emit(EVENTS.RENDITION.LAYOUT, props, changed);
+					};
+				}
+				this._layout.on(EVENTS.LAYOUT.UPDATED, this._onLayoutUpdated);
+			}
 
 		if (this.manager && this._layout) {
 			this.manager.applyLayout(this._layout);
@@ -962,38 +992,102 @@ class Rendition {
 		return located;
 	}
 
-	/**
-	 * Remove and Clean Up the Rendition
-	 */
-	destroy(){
-		// Clear the queue
-		// this.q.clear();
-		// this.q = undefined;
+		/**
+		 * Remove and Clean Up the Rendition
+		 */
+		destroy(){
+			if (this._destroyed) {
+				return;
+			}
+			this._destroyed = true;
 
-		this.manager && this.manager.destroy();
+			if (this.q && typeof this.q.stop === "function") {
+				this.q.stop();
+			}
 
-		this.book = undefined;
+			if (this._layout && this._onLayoutUpdated && typeof this._layout.off === "function") {
+				try {
+					this._layout.off(EVENTS.LAYOUT.UPDATED, this._onLayoutUpdated);
+				} catch (e) {
+					// NOOP
+				}
+			}
+			this._onLayoutUpdated = undefined;
 
-		// this.views = null;
+			if (this.manager) {
+				if (this._onManagerAdded && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.ADDED, this._onManagerAdded);
+				}
+				if (this._onManagerRemoved && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.REMOVED, this._onManagerRemoved);
+				}
+				if (this._onManagerResized && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.RESIZED, this._onManagerResized);
+				}
+				if (this._onManagerOrientationChange && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.ORIENTATION_CHANGE, this._onManagerOrientationChange);
+				}
+				if (this._onManagerScrolled && typeof this.manager.off === "function") {
+					this.manager.off(EVENTS.MANAGERS.SCROLLED, this._onManagerScrolled);
+				}
 
-		// this.hooks.display.clear();
-		// this.hooks.serialize.clear();
-		// this.hooks.content.clear();
-		// this.hooks.layout.clear();
-		// this.hooks.render.clear();
-		// this.hooks.show.clear();
-		// this.hooks = {};
+				try {
+					typeof this.manager.destroy === "function" && this.manager.destroy();
+				} catch (e) {
+					// NOOP
+				}
+			}
 
-		// this.themes.destroy();
-		// this.themes = undefined;
+			this._onManagerAdded = undefined;
+			this._onManagerRemoved = undefined;
+			this._onManagerResized = undefined;
+			this._onManagerOrientationChange = undefined;
+			this._onManagerScrolled = undefined;
 
-		// this.epubcfi = undefined;
+			const spineContentHooks =
+				this.book &&
+				this.book.spine &&
+				this.book.spine.hooks &&
+				this.book.spine.hooks.content;
+			if (spineContentHooks && typeof spineContentHooks.deregister === "function") {
+				this._onSpineInjectIdentifier &&
+					spineContentHooks.deregister(this._onSpineInjectIdentifier);
+				this._onSpineInjectStylesheet &&
+					spineContentHooks.deregister(this._onSpineInjectStylesheet);
+				this._onSpineInjectScript &&
+					spineContentHooks.deregister(this._onSpineInjectScript);
+			}
 
-		// this.starting = undefined;
-		// this.started = undefined;
+			this._onSpineInjectIdentifier = undefined;
+			this._onSpineInjectStylesheet = undefined;
+			this._onSpineInjectScript = undefined;
 
+			if (this.hooks) {
+				for (const key in this.hooks) {
+					const hook = this.hooks[key];
+					hook && typeof hook.clear === "function" && hook.clear();
+				}
+			}
 
-	}
+			if (this.themes && typeof this.themes.destroy === "function") {
+				this.themes.destroy();
+			}
+
+			this.themes = undefined;
+			this.annotations = undefined;
+			this.hooks = undefined;
+
+			this.manager = undefined;
+			this.View = undefined;
+			this.ViewManager = undefined;
+			this.book = undefined;
+			this.displaying = undefined;
+			this.location = undefined;
+			this._layout = undefined;
+			this.q = undefined;
+			this.starting = undefined;
+			this.started = undefined;
+		}
 
 	/**
 	 * Pass the events from a view's Contents

--- a/src/rendition.ts
+++ b/src/rendition.ts
@@ -44,6 +44,7 @@ import ContinuousViewManager from "./managers/continuous/index";
  * @param {boolean | object} [options.snap=false] use snap scrolling
  * @param {string} [options.defaultDirection='ltr'] default text direction
  * @param {boolean} [options.allowScriptedContent=false] enable running scripts in content
+ * @param {boolean} [options.allowUnsafeScriptedContent=false] required to actually enable scripts inside the iframe sandbox (unsafe)
  * @param {boolean} [options.allowPopups=false] enable opening popup in content
  * @param {boolean | number} [options.prefetch=false] prefetch neighboring sections after display
  */
@@ -73,6 +74,7 @@ class Rendition {
 			snap: false,
 			defaultDirection: "ltr",
 			allowScriptedContent: false,
+			allowUnsafeScriptedContent: false,
 			allowPopups: false,
 			openExternalLinks: true,
 			prefetch: false,

--- a/src/utils/replacements.ts
+++ b/src/utils/replacements.ts
@@ -7,6 +7,20 @@ interface SectionLike {
 	idref?: string;
 }
 
+function isUnsafeHref(href: string): boolean {
+	if (!href || typeof href !== "string") {
+		return false;
+	}
+
+	const match = /^[\u0000-\u0020]*([a-z][a-z0-9+.-]*):/i.exec(href);
+	if (!match) {
+		return false;
+	}
+
+	const scheme = match[1].toLowerCase();
+	return scheme === "javascript" || scheme === "vbscript";
+}
+
 export function replaceBase(doc: Document | null | undefined, section: SectionLike): void {
 	var base;
 	var head;
@@ -93,6 +107,11 @@ export function replaceLinks(
 	var replaceLink = function(link){
 		var href = link.getAttribute("href");
 		if (!href) {
+			return;
+		}
+
+		if (isUnsafeHref(href)) {
+			link.removeAttribute("href");
 			return;
 		}
 

--- a/src/utils/replacements.ts
+++ b/src/utils/replacements.ts
@@ -12,7 +12,7 @@ function isUnsafeHref(href: string): boolean {
 		return false;
 	}
 
-	const match = /^[\u0000-\u0020]*([a-z][a-z0-9+.-]*):/i.exec(href);
+		const match = /^\s*([a-z][a-z0-9+.-]*):/i.exec(href);
 	if (!match) {
 		return false;
 	}

--- a/test/current-location-layout-cache.js
+++ b/test/current-location-layout-cache.js
@@ -1,0 +1,37 @@
+import assert from "assert";
+import DefaultViewManager from "../src/managers/default";
+
+describe("DefaultViewManager currentLocation layout caching", function () {
+  it("should only call updateLayout when layout is dirty", function () {
+    const calls = { updateLayout: 0 };
+    const manager = {
+      _layoutNeedsUpdate: false,
+      _stageSize: { width: 100, height: 200 },
+      isPaginated: false,
+      settings: { axis: "vertical" },
+      updateLayout() {
+        calls.updateLayout += 1;
+        this._layoutNeedsUpdate = false;
+        this._stageSize = { width: 100, height: 200 };
+      },
+      scrolledLocation() {
+        return { kind: "scrolled" };
+      },
+      paginatedLocation() {
+        return { kind: "paginated" };
+      },
+    };
+
+    DefaultViewManager.prototype.currentLocation.call(manager);
+    DefaultViewManager.prototype.currentLocation.call(manager);
+    assert.equal(calls.updateLayout, 0);
+
+    manager._layoutNeedsUpdate = true;
+    DefaultViewManager.prototype.currentLocation.call(manager);
+    assert.equal(calls.updateLayout, 1);
+
+    DefaultViewManager.prototype.currentLocation.call(manager);
+    assert.equal(calls.updateLayout, 1);
+  });
+});
+

--- a/test/destroy-cleanup.js
+++ b/test/destroy-cleanup.js
@@ -1,0 +1,94 @@
+import assert from "assert";
+import Hook from "../src/utils/hook";
+import Rendition from "../src/rendition";
+import { EVENTS } from "../src/utils/constants";
+
+function createStubManager() {
+  const listeners = new Map();
+  const calls = { on: [], off: [], destroy: 0 };
+
+  return {
+    listeners,
+    calls,
+    on(event, fn) {
+      calls.on.push([event, fn]);
+      const existing = listeners.get(event) || [];
+      existing.push(fn);
+      listeners.set(event, existing);
+      return this;
+    },
+    off(event, fn) {
+      calls.off.push([event, fn]);
+      const existing = listeners.get(event) || [];
+      const filtered = existing.filter((candidate) => candidate !== fn);
+      if (filtered.length) {
+        listeners.set(event, filtered);
+      } else {
+        listeners.delete(event);
+      }
+      return this;
+    },
+    destroy() {
+      calls.destroy += 1;
+    },
+    applyLayout() {},
+    updateFlow() {},
+    direction() {},
+    isRendered() {
+      return false;
+    },
+    clear() {},
+  };
+}
+
+function createStubBook(spineContentHook) {
+  return {
+    opened: Promise.resolve(),
+    spine: { hooks: { content: spineContentHook } },
+    package: { metadata: { layout: "reflowable", spread: "auto", direction: "ltr" } },
+    displayOptions: { fixedLayout: "false" },
+  };
+}
+
+describe("destroy() cleanup", function () {
+  it("should deregister spine content hooks registered by Rendition", async function () {
+    const spineContentHook = new Hook();
+    const manager = createStubManager();
+    const book = createStubBook(spineContentHook);
+
+    const rendition = new Rendition(book, {
+      manager,
+      stylesheet: "/styles.css",
+      script: "/script.js",
+    });
+
+    await rendition.started;
+
+    assert.equal(spineContentHook.list().length, 3);
+
+    rendition.destroy();
+
+    assert.equal(spineContentHook.list().length, 0);
+  });
+
+  it("should detach manager event listeners on Rendition.destroy()", async function () {
+    const spineContentHook = new Hook();
+    const manager = createStubManager();
+    const book = createStubBook(spineContentHook);
+
+    const rendition = new Rendition(book, { manager });
+    await rendition.started;
+
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.ADDED));
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.REMOVED));
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.RESIZED));
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.ORIENTATION_CHANGE));
+    assert.ok(manager.listeners.has(EVENTS.MANAGERS.SCROLLED));
+
+    rendition.destroy();
+
+    assert.equal(manager.calls.destroy, 1);
+    assert.equal(manager.listeners.size, 0);
+  });
+});
+

--- a/test/epubcfi-compare-binding.js
+++ b/test/epubcfi-compare-binding.js
@@ -1,0 +1,38 @@
+import assert from "assert";
+import Locations from "../src/locations";
+import PageList from "../src/pagelist";
+
+describe("EpubCFI comparator binding", function () {
+	it("binds Locations.locationFromCfi comparator (no this loss)", function () {
+		const locations = new Locations();
+		locations.load([
+			"epubcfi(/6/2[chap01]!/4/2/14)",
+			"epubcfi(/6/2[chap01]!/4/2/16)",
+			"epubcfi(/6/2[chap01]!/4/2/18)",
+		]);
+
+		assert.doesNotThrow(() =>
+			locations.locationFromCfi("epubcfi(/6/2[chap01]!/4/2/14)")
+		);
+		assert.equal(locations.locationFromCfi("epubcfi(/6/2[chap01]!/4/2/14)"), 0);
+	});
+
+	it("binds PageList.pageFromCfi comparator (no this loss)", function () {
+		const pageList = new PageList();
+		pageList.pages = [1, 2, 3];
+		pageList.locations = [
+			"epubcfi(/6/2[chap01]!/4/2/14)",
+			"epubcfi(/6/2[chap01]!/4/2/16)",
+			"epubcfi(/6/2[chap01]!/4/2/18)",
+		];
+		pageList.firstPage = 1;
+		pageList.lastPage = 3;
+		pageList.totalPages = 2;
+
+		assert.doesNotThrow(() =>
+			pageList.pageFromCfi("epubcfi(/6/2[chap01]!/4/2/16)")
+		);
+		assert.equal(pageList.pageFromCfi("epubcfi(/6/2[chap01]!/4/2/16)"), 2);
+	});
+});
+

--- a/test/epubcfi.js
+++ b/test/epubcfi.js
@@ -105,6 +105,7 @@ describe('EpubCFI', function() {
 			// Spines
 			assert.equal(epubcfi.compare("epubcfi(/6/4[cover]!/4)", "epubcfi(/6/2[cover]!/4)"), 1, "First spine is greater");
 			assert.equal(epubcfi.compare("epubcfi(/6/4[cover]!/4)", "epubcfi(/6/6[cover]!/4)"), -1, "Second spine is greater");
+			assert.equal(epubcfi.compare("epubcfi(/6[base]/4[cover]!/4)", "epubcfi(/6[base]/2[cover]!/4)"), 1, "Spine comparison ignores base ID assertions");
 
 			// First is deeper
 			assert.equal(epubcfi.compare("epubcfi(/6/2[cover]!/8/2)", "epubcfi(/6/2[cover]!/6)"), 1, "First Element is after Second");

--- a/test/iframe-sandbox-security.js
+++ b/test/iframe-sandbox-security.js
@@ -1,0 +1,43 @@
+import assert from "assert";
+import IframeView from "../src/managers/views/iframe";
+
+function sandboxTokens(iframe) {
+  const value = iframe && typeof iframe.getAttribute === "function" ? iframe.getAttribute("sandbox") : "";
+  return String(value || "")
+    .split(/\s+/)
+    .map((token) => token.trim())
+    .filter(Boolean);
+}
+
+describe("IframeView sandbox scripted content", function () {
+  it("should not enable scripts unless allowUnsafeScriptedContent is set", function () {
+    const view = new IframeView({ index: 0 }, { allowScriptedContent: true });
+    const iframe = view.create();
+    const tokens = sandboxTokens(iframe);
+
+    assert.ok(tokens.includes("allow-same-origin"));
+    assert.ok(!tokens.includes("allow-scripts"));
+  });
+
+  it("should enable scripts only with explicit allowUnsafeScriptedContent opt-in", function () {
+    const view = new IframeView(
+      { index: 0 },
+      { allowScriptedContent: true, allowUnsafeScriptedContent: true }
+    );
+    const iframe = view.create();
+    const tokens = sandboxTokens(iframe);
+
+    assert.ok(tokens.includes("allow-same-origin"));
+    assert.ok(tokens.includes("allow-scripts"));
+  });
+
+  it("should keep allow-scripts disabled when allowScriptedContent is false", function () {
+    const view = new IframeView({ index: 0 }, { allowUnsafeScriptedContent: true });
+    const iframe = view.create();
+    const tokens = sandboxTokens(iframe);
+
+    assert.ok(tokens.includes("allow-same-origin"));
+    assert.ok(!tokens.includes("allow-scripts"));
+  });
+});
+

--- a/test/replace-links-delegation.js
+++ b/test/replace-links-delegation.js
@@ -1,0 +1,52 @@
+import assert from "assert";
+import { replaceLinks } from "../src/utils/replacements";
+
+describe("replaceLinks event delegation", function () {
+  it("should attach one delegated click handler per contents", function () {
+    const contents = document.createElement("div");
+    document.body.appendChild(contents);
+
+    const doc = contents.ownerDocument;
+    const existingBase = doc.querySelector("base");
+    const base = existingBase || doc.createElement("base");
+    if (!existingBase) {
+      doc.head.appendChild(base);
+    }
+    base.setAttribute("href", "http://example.com/OPS/ch1.xhtml");
+
+    const anchor = doc.createElement("a");
+    anchor.setAttribute("href", "#note");
+    const span = doc.createElement("span");
+    span.textContent = "note";
+    anchor.appendChild(span);
+    contents.appendChild(anchor);
+
+    let clickListenerAdds = 0;
+    const originalAdd = contents.addEventListener.bind(contents);
+    contents.addEventListener = (type, listener, options) => {
+      if (type === "click") {
+        clickListenerAdds += 1;
+      }
+      return originalAdd(type, listener, options);
+    };
+
+    const calls = [];
+    const fn = (href, link) => calls.push({ href, link });
+
+    replaceLinks(contents, fn);
+    replaceLinks(contents, fn);
+
+    assert.equal(clickListenerAdds, 1);
+
+    span.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    assert.equal(calls.length, 1);
+    assert.ok(String(calls[0].href).indexOf("#note") !== -1);
+    assert.equal(calls[0].link, anchor);
+
+    document.body.removeChild(contents);
+    if (!existingBase) {
+      doc.head.removeChild(base);
+    }
+  });
+});
+

--- a/test/resources-security.js
+++ b/test/resources-security.js
@@ -1,0 +1,132 @@
+import assert from "assert";
+import Resources from "../src/resources";
+import { replaceLinks } from "../src/utils/replacements";
+
+function createResources() {
+	return new Resources(
+		{},
+		{
+			replacements: "none",
+			lazy: true,
+			resolver: (href) => href,
+			request: async () => {
+				throw new Error("unexpected request");
+			},
+		}
+	);
+}
+
+describe("Resources security", function () {
+	it("removes unsafe javascript: URLs from common attributes", async function () {
+		const resources = createResources();
+
+		const markup =
+			'<!doctype html><html><head><link rel="stylesheet" href="javascript:alert(1)"></head>' +
+			'<body>' +
+			'<img src="javascript:alert(1)">' +
+			'<object data="javascript:alert(1)"></object>' +
+			"</body></html>";
+
+		const doc = new DOMParser().parseFromString(markup, "text/html");
+
+		await resources.replaceDocument(doc, "https://example.invalid/chapter.xhtml", "parent", [
+			"https://example.invalid/chapter.xhtml",
+		]);
+
+		const link = doc.querySelector('link[rel="stylesheet"]');
+		assert.ok(link, "stylesheet link exists");
+		assert.equal(link.hasAttribute("href"), false, "unsafe link[href] removed");
+
+		const img = doc.querySelector("img");
+		assert.ok(img, "img exists");
+		assert.equal(img.hasAttribute("src"), false, "unsafe img[src] removed");
+
+		const obj = doc.querySelector("object");
+		assert.ok(obj, "object exists");
+		assert.equal(obj.hasAttribute("data"), false, "unsafe object[data] removed");
+	});
+
+	it("filters unsafe javascript: candidates from srcset", async function () {
+		const resources = createResources();
+
+		const markup = '<img srcset="javascript:alert(1) 1x, cover.png 2x">';
+		const doc = new DOMParser().parseFromString(markup, "text/html");
+
+		await resources.replaceDocument(doc, "https://example.invalid/chapter.xhtml", "parent", [
+			"https://example.invalid/chapter.xhtml",
+		]);
+
+		const img = doc.querySelector("img");
+		assert.ok(img, "img exists");
+
+		const srcset = img.getAttribute("srcset") || "";
+		assert.ok(srcset.indexOf("javascript:") === -1, "unsafe srcset url removed");
+		assert.ok(srcset.indexOf("cover.png") !== -1, "safe srcset candidate preserved");
+	});
+
+	it("rewrites unsafe javascript: URLs inside CSS url() to empty", async function () {
+		const resources = createResources();
+
+		const markup =
+			"<html><head><style>body{background:url(\"javascript:alert(1)\")}</style></head>" +
+			"<body><div style=\"background:url(javascript:alert(1))\"></div></body></html>";
+		const doc = new DOMParser().parseFromString(markup, "text/html");
+
+		await resources.replaceDocument(doc, "https://example.invalid/chapter.xhtml", "parent", [
+			"https://example.invalid/chapter.xhtml",
+		]);
+
+		const styleTag = doc.querySelector("style");
+		assert.ok(styleTag, "style tag exists");
+		assert.ok(
+			(styleTag.textContent || "").indexOf("javascript:") === -1,
+			"unsafe css url removed from <style>"
+		);
+
+		const div = doc.querySelector("div");
+		assert.ok(div, "div exists");
+		assert.ok((div.getAttribute("style") || "").indexOf("javascript:") === -1, "unsafe css url removed from style attr");
+	});
+
+	it("removes unsafe xlink:href attributes", async function () {
+		const resources = createResources();
+
+		const markup =
+			'<?xml version="1.0" encoding="UTF-8"?>' +
+			'<html xmlns="http://www.w3.org/1999/xhtml" xmlns:xlink="http://www.w3.org/1999/xlink">' +
+			"<body>" +
+			'<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">' +
+			'<a xlink:href="javascript:alert(1)"></a>' +
+			"</svg>" +
+			"</body></html>";
+
+		const doc = new DOMParser().parseFromString(markup, "application/xhtml+xml");
+
+		await resources.replaceDocument(doc, "https://example.invalid/chapter.xhtml", "parent", [
+			"https://example.invalid/chapter.xhtml",
+		]);
+
+		const el = doc.querySelector("a");
+		assert.ok(el, "svg anchor exists");
+		assert.equal(
+			el.getAttributeNS("http://www.w3.org/1999/xlink", "href"),
+			null,
+			"unsafe xlink:href removed"
+		);
+	});
+
+	it("removes unsafe javascript: links during link replacement", function () {
+		const markup = '<div><a href="javascript:alert(1)">click</a></div>';
+		const doc = new DOMParser().parseFromString(markup, "text/html");
+		const root = doc.querySelector("div");
+		assert.ok(root, "root exists");
+
+		replaceLinks(root, () => {
+			throw new Error("unexpected callback invocation");
+		});
+
+		const a = doc.querySelector("a");
+		assert.ok(a, "anchor exists");
+		assert.equal(a.hasAttribute("href"), false, "unsafe a[href] removed");
+	});
+});

--- a/test/search-worker-csp.js
+++ b/test/search-worker-csp.js
@@ -1,0 +1,93 @@
+import assert from "assert";
+import Book from "../src/book";
+
+function setProp(obj, key, value) {
+	try {
+		obj[key] = value;
+	} catch (e) {
+		Object.defineProperty(obj, key, {
+			value,
+			configurable: true,
+			writable: true,
+		});
+	}
+}
+
+describe("Book.createSearchWorker CSP", function () {
+	it("uses searchWorkerUrl when provided (avoids blob: worker)", function () {
+		const originalWorker = window.Worker;
+		const originalCreateObjectURL = URL.createObjectURL;
+		const originalRevokeObjectURL = URL.revokeObjectURL;
+
+		try {
+			let createObjectURLCalled = false;
+			setProp(URL, "createObjectURL", () => {
+				createObjectURLCalled = true;
+				throw new Error("URL.createObjectURL should not be called when searchWorkerUrl is set");
+			});
+			setProp(URL, "revokeObjectURL", () => {
+				throw new Error("URL.revokeObjectURL should not be called when searchWorkerUrl is set");
+			});
+
+			let workerUrl = null;
+			function FakeWorker(url) {
+				workerUrl = url;
+				this.terminate = () => {};
+			}
+			setProp(window, "Worker", FakeWorker);
+
+			const worker = Book.prototype.createSearchWorker.call({
+				settings: { searchWorkerUrl: "https://example.invalid/search.worker.js" },
+			});
+
+			assert.ok(worker, "worker is returned");
+			assert.equal(workerUrl, "https://example.invalid/search.worker.js");
+			assert.equal(createObjectURLCalled, false);
+		} finally {
+			setProp(window, "Worker", originalWorker);
+			setProp(URL, "createObjectURL", originalCreateObjectURL);
+			setProp(URL, "revokeObjectURL", originalRevokeObjectURL);
+		}
+	});
+
+	it("falls back to blob: worker when searchWorkerUrl is not set", function () {
+		const originalWorker = window.Worker;
+		const originalCreateObjectURL = URL.createObjectURL;
+		const originalRevokeObjectURL = URL.revokeObjectURL;
+
+		try {
+			let createObjectURLCalled = false;
+			let revokeObjectURLCalled = false;
+			let createdWorkerUrl = null;
+
+			setProp(URL, "createObjectURL", () => {
+				createObjectURLCalled = true;
+				return "blob:fake-worker-url";
+			});
+			setProp(URL, "revokeObjectURL", (url) => {
+				revokeObjectURLCalled = true;
+				assert.equal(url, "blob:fake-worker-url");
+			});
+
+			function FakeWorker(url) {
+				createdWorkerUrl = url;
+				this.terminate = () => {};
+			}
+			setProp(window, "Worker", FakeWorker);
+
+			const worker = Book.prototype.createSearchWorker.call({
+				settings: {},
+			});
+
+			assert.ok(worker, "worker is returned");
+			assert.equal(createObjectURLCalled, true);
+			assert.equal(revokeObjectURLCalled, true);
+			assert.equal(createdWorkerUrl, "blob:fake-worker-url");
+		} finally {
+			setProp(window, "Worker", originalWorker);
+			setProp(URL, "createObjectURL", originalCreateObjectURL);
+			setProp(URL, "revokeObjectURL", originalRevokeObjectURL);
+		}
+	});
+});
+

--- a/types/book.d.ts
+++ b/types/book.d.ts
@@ -46,7 +46,8 @@ export interface BookOptions {
   metrics?: boolean | BookMetricsOptions,
   prefetchDistance?: number,
   maxLoadedSections?: number,
-  lazyResources?: boolean
+  lazyResources?: boolean,
+  searchWorkerUrl?: string
 }
 
 export default class Book {

--- a/types/managers/view.d.ts
+++ b/types/managers/view.d.ts
@@ -7,12 +7,14 @@ export interface ViewSettings {
   axis?: string,
   flow?: string,
   layout?: Layout,
-  method?: string,
-  width?: number,
-  height?: number,
-  forceEvenPages?: boolean,
-  allowScriptedContent?: boolean
-}
+	  method?: string,
+	  width?: number,
+	  height?: number,
+	  forceEvenPages?: boolean,
+	  allowScriptedContent?: boolean,
+	  allowUnsafeScriptedContent?: boolean,
+	  allowPopups?: boolean
+	}
 
 export default class View {
   constructor(section: Section, options: ViewSettings);

--- a/types/rendition.d.ts
+++ b/types/rendition.d.ts
@@ -29,15 +29,16 @@ export interface RenditionOptions {
   script?: string,
   infinite?: boolean,
   overflow?: string,
-  snap?: boolean | object,
-  defaultDirection?: string,
-  allowScriptedContent?: boolean,
-  allowPopups?: boolean,
-  openExternalLinks?: boolean,
-  prefetch?: boolean | number,
-  footnotes?: boolean | { detect?: boolean, extract?: boolean },
-  fixedLayout?: null | { zoom?: number | "fit-width" | "fit-page" }
-}
+	  snap?: boolean | object,
+	  defaultDirection?: string,
+	  allowScriptedContent?: boolean,
+	  allowUnsafeScriptedContent?: boolean,
+	  allowPopups?: boolean,
+	  openExternalLinks?: boolean,
+	  prefetch?: boolean | number,
+	  footnotes?: boolean | { detect?: boolean, extract?: boolean },
+	  fixedLayout?: null | { zoom?: number | "fit-width" | "fit-page" }
+	}
 
 export interface DisplayedLocation {
   index: number,


### PR DESCRIPTION
Fixes a crash when passing EpubCFI.compare as an unbound callback (this loss) from Locations/PageList into sorted-array helpers.

- Bind comparator in Locations.locationFromCfi and PageList.pageFromCfi
- Add regression tests to cover callback binding