### PR TITLE
refactor: harden annotations and XML parsing

### DIFF
--- a/docs/REFACTOR.md
+++ b/docs/REFACTOR.md
@@ -6,7 +6,7 @@
 
 ## 当前基线
 
-- Base: `origin/dev` @ `853275a`
+- Base: `origin/dev` @ `afef30a`
 - Last updated: 2026-02-23
 
 ## 已阅读模块（Reviewed）
@@ -18,10 +18,13 @@
 
 ### Source (src/)
 
+- [x] `src/annotations.ts`（Annotations store + view lifecycle hooks）
 - [x] `src/archive.ts`（Archive: url cache + revoke lifecycle）
 - [x] `src/book.ts`（Book public API surface）
 - [x] `src/book/init.ts`（Book initialization: loading/loaded/ready）
 - [x] `src/book/unpack.ts`（Packaging unpack + navigation / pagelist loading）
+- [x] `src/container.ts`（Container XML parsing）
+- [x] `src/displayoptions.ts`（DisplayOptions XML parsing）
 - [x] `src/epubcfi.ts`（EpubCFI facade + method wiring）
 - [x] `src/epubcfi/compare.ts`（CFI ordering）
 - [x] `src/epubcfi/parse.ts`（CFI parsing and type checks）
@@ -58,6 +61,8 @@
 - 2026-02-23：`src/pdf/book*.ts` 清理无意义的转义（降低 `no-useless-escape` 告警噪音，保持输出不变）。
 - 2026-02-23：统一 `Archive` / `ZipJsArchive` / `Store` 的 `revokeUrl()` 语义：仅对 object URL 执行 revoke，并在 revoke 后清理 cache（提升鲁棒性，避免返回已失效的 blob URL）。
 - 2026-02-23：`src/utils/core/dom.ts` 抽取 `bounds()` / `borders()` 的 computed-style 求和逻辑并复用常量 props 列表（减少重复分配，保持行为不变）。
+- 2026-02-23：`src/annotations.ts` 提取 hash 计算与参数类型，减少重复索引更新，并对注入/清理流程做缺失容错（无行为变更，提升可维护性）。
+- 2026-02-23：`src/container.ts` / `src/displayoptions.ts` 补全类型签名并加强 XML 字段读取的容错（无行为变更，提升健壮性）。
 
 ## 重构点（Backlog）
 
@@ -70,12 +75,9 @@
 
 ### Source (src/)
 
-- [ ] `src/annotations.ts`
-- [ ] `src/container.ts`
 - [ ] `src/contents/`
 - [ ] `src/contents.ts`
 - [ ] `src/core/`
-- [ ] `src/displayoptions.ts`
 - [ ] `src/index.ts`
 - [ ] `src/layout.ts`
 - [ ] `src/managers/`

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -3,6 +3,19 @@ import EpubCFI from "./epubcfi";
 import { EVENTS } from "./utils/constants";
 
 type AnnotationType = "highlight" | "underline" | "mark";
+type AnnotationOptions = {
+	type: AnnotationType;
+	cfiRange: string;
+	data?: any;
+	sectionIndex: number;
+	cb?: any;
+	className?: string;
+	styles?: any;
+};
+
+function annotationHash(cfiRange: string, type: AnnotationType): string {
+	return encodeURI(cfiRange + type);
+}
 
 /**
 	* Handles managing adding & removing Annotations
@@ -41,10 +54,10 @@ class Annotations {
 	 * @returns {Annotation} annotation
 	 */
 	add (type: AnnotationType, cfiRange: string, data?: any, cb?: any, className?: string, styles?: any): Annotation {
-		let hash = encodeURI(cfiRange + type);
-		let cfi = new EpubCFI(cfiRange);
-		let sectionIndex = cfi.spinePos;
-		let annotation = new Annotation({
+		const hash = annotationHash(cfiRange, type);
+		const cfi = new EpubCFI(cfiRange);
+		const sectionIndex = cfi.spinePos;
+		const annotation = new Annotation({
 			type,
 			cfiRange,
 			data,
@@ -62,9 +75,8 @@ class Annotations {
 			this._annotationsBySectionIndex[sectionIndex] = [hash];
 		}
 
-		let views = this.rendition.views();
-
-		views.forEach( (view) => {
+		const views = this.rendition.views();
+		views.forEach((view) => {
 			if (annotation.sectionIndex === view.index) {
 				annotation.attach(view);
 			}
@@ -79,18 +91,19 @@ class Annotations {
 	 * @param {string} type Type of annotation to add: "highlight", "underline", "mark"
 	 */
 	remove (cfiRange: string, type: AnnotationType) {
-		let hash = encodeURI(cfiRange + type);
+		const hash = annotationHash(cfiRange, type);
 
 		if (hash in this._annotations) {
-			let annotation = this._annotations[hash];
+			const annotation = this._annotations[hash];
 
 			if (type && annotation.type !== type) {
 				return;
 			}
 
-			let views = this.rendition.views();
-			views.forEach( (view) => {
-				this._removeFromAnnotationBySectionIndex(annotation.sectionIndex, hash);
+			this._removeFromAnnotationBySectionIndex(annotation.sectionIndex, hash);
+
+			const views = this.rendition.views();
+			views.forEach((view) => {
 				if (annotation.sectionIndex === view.index) {
 					annotation.detach(view);
 				}
@@ -113,7 +126,7 @@ class Annotations {
 	 * @private
 	 */
 	_annotationsAt (index: number): string[] {
-		return this._annotationsBySectionIndex[index];
+		return this._annotationsBySectionIndex[index] || [];
 	}
 
 
@@ -166,12 +179,14 @@ class Annotations {
 	 * @private
 	 */
 	inject (view: any) {
-		let sectionIndex = view.index;
+		const sectionIndex = view.index;
 		if (sectionIndex in this._annotationsBySectionIndex) {
-			let annotations = this._annotationsBySectionIndex[sectionIndex];
+			const annotations = this._annotationsBySectionIndex[sectionIndex];
 			annotations.forEach((hash) => {
-				let annotation = this._annotations[hash];
-				annotation.attach(view);
+				const annotation = this._annotations[hash];
+				if (annotation) {
+					annotation.attach(view);
+				}
 			});
 		}
 	}
@@ -182,12 +197,14 @@ class Annotations {
 	 * @private
 	 */
 	clear (view: any) {
-		let sectionIndex = view.index;
+		const sectionIndex = view.index;
 		if (sectionIndex in this._annotationsBySectionIndex) {
-			let annotations = this._annotationsBySectionIndex[sectionIndex];
+			const annotations = this._annotationsBySectionIndex[sectionIndex];
 			annotations.forEach((hash) => {
-				let annotation = this._annotations[hash];
-				annotation.detach(view);
+				const annotation = this._annotations[hash];
+				if (annotation) {
+					annotation.detach(view);
+				}
 			});
 		}
 	}
@@ -238,15 +255,8 @@ class Annotation {
 	off: (event: string, listener?: (...args: any[]) => void) => this;
 	emit: (event: string, ...args: any[]) => boolean;
 
-	constructor ({
-		type,
-		cfiRange,
-		data,
-		sectionIndex,
-		cb,
-		className,
-		styles
-	}) {
+	constructor (options: AnnotationOptions) {
+		const {type, cfiRange, data, sectionIndex, cb, className, styles} = options;
 		this.type = type;
 		this.cfiRange = cfiRange;
 		this.data = data;
@@ -269,16 +279,20 @@ class Annotation {
 	 * Add to a view
 	 * @param {View} view
 	 */
-		attach (view: any) {
-			let {cfiRange, data, type, cb, className, styles} = this;
-			let result;
+	attach (view: any) {
+		const {cfiRange, data, type, cb, className, styles} = this;
+		let result;
 
-		if (type === "highlight") {
-			result = view.highlight(cfiRange, data, cb, className, styles);
-		} else if (type === "underline") {
-			result = view.underline(cfiRange, data, cb, className, styles);
-		} else if (type === "mark") {
-			result = view.mark(cfiRange, data, cb);
+		switch (type) {
+			case "highlight":
+				result = view.highlight(cfiRange, data, cb, className, styles);
+				break;
+			case "underline":
+				result = view.underline(cfiRange, data, cb, className, styles);
+				break;
+			case "mark":
+				result = view.mark(cfiRange, data, cb);
+				break;
 		}
 
 		this.mark = result;
@@ -291,16 +305,20 @@ class Annotation {
 	 * @param {View} view
 	 */
 	detach (view: any) {
-		let {cfiRange, type} = this;
+		const {cfiRange, type} = this;
 		let result;
 
 		if (view) {
-			if (type === "highlight") {
-				result = view.unhighlight(cfiRange);
-			} else if (type === "underline") {
-				result = view.ununderline(cfiRange);
-			} else if (type === "mark") {
-				result = view.unmark(cfiRange);
+			switch (type) {
+				case "highlight":
+					result = view.unhighlight(cfiRange);
+					break;
+				case "underline":
+					result = view.ununderline(cfiRange);
+					break;
+				case "mark":
+					result = view.unmark(cfiRange);
+					break;
 			}
 		}
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -25,16 +25,13 @@ class Container {
 	 * Parse the Container XML
 	 * @param  {document} containerDocument
 	 */
-	parse(containerDocument){
+	parse(containerDocument: any): void {
 		//-- <rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>
-		var rootfile;
-
 		if(!containerDocument) {
 			throw new Error("Container File Not Found");
 		}
 
-		rootfile = qs(containerDocument, "rootfile");
-
+		const rootfile = qs(containerDocument, "rootfile");
 		if(!rootfile) {
 			throw new Error("No RootFile Found");
 		}
@@ -45,7 +42,7 @@ class Container {
 		}
 
 		this.packagePath = packagePath;
-		this.directory = path.dirname(this.packagePath);
+		this.directory = path.dirname(packagePath);
 		this.encoding = containerDocument.xmlEncoding;
 	}
 

--- a/src/displayoptions.ts
+++ b/src/displayoptions.ts
@@ -1,4 +1,4 @@
-import {qs, qsa } from "./utils/core";
+import {qs, qsa} from "./utils/core";
 
 /**
  * Open DisplayOptions Format Parser
@@ -27,39 +27,44 @@ class DisplayOptions {
 	 * @param  {document} displayOptionsDocument XML
 	 * @return {DisplayOptions} self
 	 */
-	parse(displayOptionsDocument: any): this {
-		if(!displayOptionsDocument) {
-			return this;
-		}
-
-		const displayOptionsNode = qs(displayOptionsDocument, "display_options");
-		if(!displayOptionsNode) {
-			return this;
-		} 
-
-		const options = qsa(displayOptionsNode, "option");
-		options.forEach((el) => {
-			let value = "";
-
-			if (el.childNodes.length) {
-				value = el.childNodes[0].nodeValue;
+		parse(displayOptionsDocument: any): this {
+			if(!displayOptionsDocument) {
+				return this;
 			}
 
-			switch (el.attributes.name.value) {
-			    case "interactive":
-			        this.interactive = value;
-			        break;
-			    case "fixed-layout":
-			        this.fixedLayout = value;
-			        break;
-			    case "open-to-spread":
-			        this.openToSpread = value;
-			        break;
-			    case "orientation-lock":
-			        this.orientationLock = value;
-			        break;
+			const displayOptionsNode = qs(displayOptionsDocument, "display_options");
+			if(!displayOptionsNode) {
+				return this;
 			}
-		});
+
+			const options = qsa(displayOptionsNode, "option");
+			options.forEach((el) => {
+				let value = "";
+
+				if (el.childNodes.length) {
+					value = el.childNodes[0].nodeValue || "";
+				}
+
+				const name = el.getAttribute("name");
+				if (!name) {
+					return;
+				}
+
+				switch (name) {
+					case "interactive":
+						this.interactive = value;
+						break;
+					case "fixed-layout":
+						this.fixedLayout = value;
+						break;
+					case "open-to-spread":
+						this.openToSpread = value;
+						break;
+					case "orientation-lock":
+						this.orientationLock = value;
+						break;
+				}
+			});
 
 		return this;
 	}


### PR DESCRIPTION
Summary:
- Refactor annotations internals (hash helper, remove redundant index updates, tolerate missing entries during inject/clear, switch-based attach/detach).
- Harden XML parsing in Container and DisplayOptions (typed parse signatures, remove var, tolerate missing name/value).

Docs:
- Update docs/REFACTOR.md baseline and reviewed modules.

Verification:
- npm run lint
- npm run typecheck
- npm test
